### PR TITLE
Fix DataGrid sort navigation crash

### DIFF
--- a/SmbExplorerCompanion.WPF/Views/HistoricalTeamsView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/HistoricalTeamsView.xaml
@@ -8,6 +8,8 @@
              d:DataContext="{d:DesignInstance viewModels:HistoricalTeamsViewModel}">
     <ScrollViewer Name="ScrollViewer">
         <DataGrid
+            Name="TeamsDataGrid"
+            IsReadOnly="True"
             ItemsSource="{Binding HistoricalTeams}"
             SelectedItem="{Binding SelectedHistoricalTeam}"
             AutoGenerateColumns="True"

--- a/SmbExplorerCompanion.WPF/Views/HistoricalTeamsView.xaml.cs
+++ b/SmbExplorerCompanion.WPF/Views/HistoricalTeamsView.xaml.cs
@@ -10,8 +10,14 @@ public partial class HistoricalTeamsView : IDisposable
     {
         InitializeComponent();
         ScrollViewer.PreviewMouseWheel += ListViewScrollViewer_PreviewMouseWheel;
+        TeamsDataGrid.Sorting += DataGridOnSorting;
     }
-    
+
+    private void DataGridOnSorting(object sender, DataGridSortingEventArgs e)
+    {
+        TeamsDataGrid.SelectedItem = null;
+    }
+
     private void ListViewScrollViewer_PreviewMouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)
     {
         var scv = (ScrollViewer)sender;
@@ -44,6 +50,7 @@ public partial class HistoricalTeamsView : IDisposable
     public void Dispose()
     {
         ScrollViewer.PreviewMouseWheel -= ListViewScrollViewer_PreviewMouseWheel;
+        TeamsDataGrid.Sorting -= DataGridOnSorting;
         GC.SuppressFinalize(this);
     }
 }

--- a/SmbExplorerCompanion.WPF/Views/TeamOverviewView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TeamOverviewView.xaml
@@ -63,6 +63,8 @@
 
                 <ScrollViewer>
                     <DataGrid
+                        Name="TeamSeasonsDataGrid"
+                        IsReadOnly="True"
                         ItemsSource="{Binding TeamOverview.TeamHistory}"
                         AutoGenerateColumns="True"
                         CanUserAddRows="False"
@@ -81,6 +83,7 @@
 
                 <ScrollViewer>
                     <DataGrid
+                        Name="TopPlayersDataGrid"
                         ItemsSource="{Binding TeamOverview.TopPlayers}"
                         SelectedItem="{Binding SelectedPlayer}"
                         AutoGenerateColumns="True"
@@ -89,7 +92,8 @@
                         CanUserReorderColumns="False"
                         CanUserSortColumns="True"
                         CanUserResizeColumns="True"
-                        SelectionMode="Single" />
+                        SelectionMode="Single"
+                        IsReadOnly="True" />
                 </ScrollViewer>
             </Grid>
         </StackPanel>

--- a/SmbExplorerCompanion.WPF/Views/TeamOverviewView.xaml.cs
+++ b/SmbExplorerCompanion.WPF/Views/TeamOverviewView.xaml.cs
@@ -1,11 +1,29 @@
-﻿using System.Windows.Controls;
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Controls;
+using System.Windows.Data;
 
 namespace SmbExplorerCompanion.WPF.Views;
 
-public partial class TeamOverviewView : UserControl
+public partial class TeamOverviewView : UserControl, IDisposable
 {
     public TeamOverviewView()
     {
         InitializeComponent();
+        
+        TopPlayersDataGrid.Sorting += DataGridOnSorting;
+        TeamSeasonsDataGrid.Sorting += DataGridOnSorting;
+    }
+
+    private void DataGridOnSorting(object sender, DataGridSortingEventArgs e)
+    {
+        TopPlayersDataGrid.SelectedItem = null;
+    }
+
+    public void Dispose()
+    {
+        TopPlayersDataGrid.Sorting -= DataGridOnSorting;
+        TeamSeasonsDataGrid.Sorting -= DataGridOnSorting;
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
Force DataGrids to be read only and set selected item to null to prevent exception on item selected after DataGrid sorting

Closes #22 