### PR TITLE
Fix career rate stat weights

### DIFF
--- a/SmbExplorerCompanion.Database/Services/PlayerRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/PlayerRepository.cs
@@ -1149,10 +1149,13 @@ public class PlayerRepository : IPlayerRepository
                     .SelectMany(y => y.BattingStats)
                     .Sum(y => ((y.OpsPlus ?? 0) - 95) * y.PlateAppearances * BattingScalingFactor +
                               (y.StolenBases - y.CaughtStealing) * BaserunningScalingFactor),
-                // Simply average the OPS+ values
                 OpsPlus = x.PlayerSeasons
-                    .SelectMany(y => y.BattingStats)
-                    .Average(y => y.OpsPlus ?? 0),
+                              .SelectMany(y => y.BattingStats)
+                              .Sum(y => (y.OpsPlus ?? 0) * y.PlateAppearances)
+                          /
+                          x.PlayerSeasons
+                              .SelectMany(y => y.BattingStats)
+                              .Sum(y => y.PlateAppearances),
                 Singles = x.PlayerSeasons.Sum(y => y.BattingStats.Sum(z => z.Singles)),
                 Doubles = x.PlayerSeasons.Sum(y => y.BattingStats.Sum(z => z.Doubles)),
                 Triples = x.PlayerSeasons.Sum(y => y.BattingStats.Sum(z => z.Triples)),
@@ -1218,13 +1221,22 @@ public class PlayerRepository : IPlayerRepository
                 WeightedOpsPlusOrEraMinus = x.PlayerSeasons
                     .SelectMany(y => y.PitchingStats)
                     .Sum(y => (((y.EraMinus ?? 0) + (y.FipMinus ?? 0)) / 2 - 95) * (y.InningsPitched ?? 0) * PitchingScalingFactor),
-                // Simply average the ERA- values, only taking into account regular season games for this calculation
-                EraMinus = x.PlayerSeasons
-                    .SelectMany(y => y.PitchingStats)
-                    .Average(y => y.EraMinus ?? 0),
-                FipMinus = x.PlayerSeasons
-                    .SelectMany(y => y.PitchingStats)
-                    .Average(y => y.FipMinus ?? 0),
+                EraMinus =
+                    x.PlayerSeasons
+                        .SelectMany(y => y.PitchingStats)
+                        .Sum(y => (y.EraMinus ?? 0) * (y.InningsPitched ?? 0))
+                    /
+                    x.PlayerSeasons
+                        .SelectMany(y => y.PitchingStats)
+                        .Sum(y => (y.InningsPitched ?? 1)),
+                FipMinus =
+                    x.PlayerSeasons
+                        .SelectMany(y => y.PitchingStats)
+                        .Sum(y => (y.FipMinus ?? 0) * (y.InningsPitched ?? 0))
+                    /
+                    x.PlayerSeasons
+                        .SelectMany(y => y.PitchingStats)
+                        .Sum(y => (y.InningsPitched ?? 1)),
                 Awards = x.PlayerSeasons
                     .SelectMany(y => y.Awards)
                     .Where(y => !omitRunnerUps || !y.OmitFromGroupings)

--- a/SmbExplorerCompanion.WPF/SmbExplorerCompanion.WPF.csproj
+++ b/SmbExplorerCompanion.WPF/SmbExplorerCompanion.WPF.csproj
@@ -7,7 +7,7 @@
         <UseWPF>true</UseWPF>
         <AssemblyName>SmbExplorerCompanion</AssemblyName>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>1.1.1</Version>
+        <Version>1.1.2</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SmbExplorerCompanion.WPF/Views/PlayerOverviewView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/PlayerOverviewView.xaml
@@ -245,6 +245,14 @@
                                 Binding="{Binding Whip, StringFormat={}{0:F2}}" />
                             <DataGridTextColumn
                                 CanUserSort="False"
+                                Header="ERA-"
+                                Binding="{Binding EraMinus, StringFormat={}{0:F1}}" />
+                            <DataGridTextColumn
+                                CanUserSort="False"
+                                Header="FIP-"
+                                Binding="{Binding FipMinus, StringFormat={}{0:F1}}" />
+                            <DataGridTextColumn
+                                CanUserSort="False"
                                 Header="Age"
                                 Binding="{Binding DisplayAge}" />
                         </DataGrid.Columns>


### PR DESCRIPTION
- Scale career OPS+, ERA-, and FIP- based on the number of plate appearances per season (for position players) or the number of innings pitched (for pitchers)
- This fixes the issue of how these stats originally were simply averaged
- Also add ERA- and FIP- to the career header grid on pitcher detail pages
- Closes #118 