### PR TITLE
Fix fielding not reflecting actual values on player overview

### DIFF
--- a/SmbExplorerCompanion.WPF/SmbExplorerCompanion.WPF.csproj
+++ b/SmbExplorerCompanion.WPF/SmbExplorerCompanion.WPF.csproj
@@ -7,7 +7,7 @@
         <UseWPF>true</UseWPF>
         <AssemblyName>SmbExplorerCompanion</AssemblyName>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SmbExplorerCompanion.WPF/Views/PlayerOverviewView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/PlayerOverviewView.xaml
@@ -1007,7 +1007,7 @@
                                 <DataGridTextColumn
                                     CanUserSort="True"
                                     Header="Fielding"
-                                    Binding="{Binding Speed}" />
+                                    Binding="{Binding Fielding}" />
                                 <DataGridTextColumn
                                     CanUserSort="True"
                                     Header="Arm"


### PR DESCRIPTION
Fixes a bug where the fielding values are bound to the speed values, causing fielding to not be displayed properly