### PR TITLE
Add fallbacks for nonstandard length games causing no qualifiers for BA and ERA

### DIFF
--- a/SmbExplorerCompanion.WPF/SmbExplorerCompanion.WPF.csproj
+++ b/SmbExplorerCompanion.WPF/SmbExplorerCompanion.WPF.csproj
@@ -7,7 +7,7 @@
         <UseWPF>true</UseWPF>
         <AssemblyName>SmbExplorerCompanion</AssemblyName>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>1.2.3</Version>
+        <Version>1.2.4</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes #138 

- Not a permanent fix, but this should be good enough to allow qualifiers for rate stats. In the future, we should probably have a configuration screen that tracks the # innings per game and adjusts the qualifiers calculation for BA and ERA app-wide depending on the # innings per game value
- In the case that this is not enough to locate a leader in the category, it throws a more user-friendly exception