### PR TITLE
Season range grid filters

### DIFF
--- a/SmbExplorerCompanion.Core/Commands/Queries/Players/GetTopBattingCareersRequest.cs
+++ b/SmbExplorerCompanion.Core/Commands/Queries/Players/GetTopBattingCareersRequest.cs
@@ -2,18 +2,22 @@
 using MediatR;
 using SmbExplorerCompanion.Core.Entities.Players;
 using SmbExplorerCompanion.Core.Interfaces;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 
 namespace SmbExplorerCompanion.Core.Commands.Queries.Players;
 
 public class GetTopBattingCareersRequest : IRequest<List<PlayerCareerBattingDto>>
 {
-    public GetTopBattingCareersRequest(int? pageNumber = null,
+    public GetTopBattingCareersRequest(
+        SeasonRange? seasonRange = null,
+        int? pageNumber = null,
         int? limit = null,
         string? orderBy = null,
         bool descending = true,
         bool onlyHallOfFamers = false,
         int? primaryPositionId = null)
     {
+        SeasonRange = seasonRange;
         PageNumber = pageNumber;
         Limit = limit;
         OrderBy = orderBy;
@@ -28,6 +32,7 @@ public class GetTopBattingCareersRequest : IRequest<List<PlayerCareerBattingDto>
     private bool Descending { get; }
     private bool OnlyHallOfFamers { get; }
     private int? PrimaryPositionId { get; }
+    private SeasonRange? SeasonRange { get; }
 
     private static ImmutableArray<string> ValidOrderByProperties { get; } = ImmutableArray.Create(
         nameof(PlayerCareerBattingDto.TotalSalary),
@@ -73,6 +78,7 @@ public class GetTopBattingCareersRequest : IRequest<List<PlayerCareerBattingDto>
                 descending: request.Descending,
                 onlyHallOfFamers: request.OnlyHallOfFamers,
                 primaryPositionId: request.PrimaryPositionId,
+                seasons: request.SeasonRange,
                 cancellationToken: cancellationToken);
         }
     }

--- a/SmbExplorerCompanion.Core/Commands/Queries/Players/GetTopPitchingCareersRequest.cs
+++ b/SmbExplorerCompanion.Core/Commands/Queries/Players/GetTopPitchingCareersRequest.cs
@@ -2,18 +2,22 @@
 using MediatR;
 using SmbExplorerCompanion.Core.Entities.Players;
 using SmbExplorerCompanion.Core.Interfaces;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 
 namespace SmbExplorerCompanion.Core.Commands.Queries.Players;
 
 public class GetTopPitchingCareersRequest : IRequest<List<PlayerCareerPitchingDto>>
 {
-    public GetTopPitchingCareersRequest(int? pageNumber = null,
+    public GetTopPitchingCareersRequest(
+        SeasonRange? seasonRange = null,
+        int? pageNumber = null,
         int? limit = null,
         string? orderBy = null,
         bool descending = true,
         bool onlyHallOfFamers = false,
         int? pitcherRoleId = null)
     {
+        SeasonRange = seasonRange;
         PageNumber = pageNumber;
         Limit = limit;
         OrderBy = orderBy;
@@ -28,6 +32,7 @@ public class GetTopPitchingCareersRequest : IRequest<List<PlayerCareerPitchingDt
     private bool Descending { get; }
     private bool OnlyHallOfFamers { get; }
     private int? PitcherRoleId { get; }
+    private SeasonRange? SeasonRange { get; }
 
     private static ImmutableArray<string> ValidOrderByProperties { get; } = ImmutableArray.Create(
         nameof(PlayerCareerPitchingDto.TotalSalary),

--- a/SmbExplorerCompanion.Core/Commands/Queries/Players/GetTopPitchingCareersRequest.cs
+++ b/SmbExplorerCompanion.Core/Commands/Queries/Players/GetTopPitchingCareersRequest.cs
@@ -76,6 +76,7 @@ public class GetTopPitchingCareersRequest : IRequest<List<PlayerCareerPitchingDt
                 descending: request.Descending,
                 onlyHallOfFamers: request.OnlyHallOfFamers,
                 pitcherRoleId: request.PitcherRoleId,
+                seasons: request.SeasonRange,
                 cancellationToken: cancellationToken);
         }
     }

--- a/SmbExplorerCompanion.Core/Commands/Queries/Teams/GetHistoricalTeamsRequest.cs
+++ b/SmbExplorerCompanion.Core/Commands/Queries/Teams/GetHistoricalTeamsRequest.cs
@@ -1,17 +1,18 @@
 ﻿using MediatR;
 using SmbExplorerCompanion.Core.Entities.Teams;
 using SmbExplorerCompanion.Core.Interfaces;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 
 namespace SmbExplorerCompanion.Core.Commands.Queries.Teams;
 
 public class GetHistoricalTeamsRequest : IRequest<IEnumerable<HistoricalTeamDto>>
 {
-    public GetHistoricalTeamsRequest(int? seasonId)
+    public GetHistoricalTeamsRequest(SeasonRange seasonRange)
     {
-        SeasonId = seasonId;
+        SeasonRange = seasonRange;
     }
 
-    private int? SeasonId { get; }
+    private SeasonRange SeasonRange { get; }
 
     // ReSharper disable once UnusedType.Global
     internal class GetHistoricalTeamsHandler : IRequestHandler<GetHistoricalTeamsRequest, IEnumerable<HistoricalTeamDto>>
@@ -25,6 +26,6 @@ public class GetHistoricalTeamsRequest : IRequest<IEnumerable<HistoricalTeamDto>
 
         public async Task<IEnumerable<HistoricalTeamDto>> Handle(GetHistoricalTeamsRequest request,
             CancellationToken cancellationToken) =>
-            await _teamRepository.GetHistoricalTeams(request.SeasonId, cancellationToken);
+            await _teamRepository.GetHistoricalTeams(request.SeasonRange, cancellationToken);
     }
 }

--- a/SmbExplorerCompanion.Core/Interfaces/IPitcherCareerRepository.cs
+++ b/SmbExplorerCompanion.Core/Interfaces/IPitcherCareerRepository.cs
@@ -1,4 +1,5 @@
 ﻿using SmbExplorerCompanion.Core.Entities.Players;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 
 namespace SmbExplorerCompanion.Core.Interfaces;
 
@@ -13,6 +14,7 @@ public interface IPitcherCareerRepository
         bool onlyHallOfFamers = false,
         int? pitcherRoleId = null,
         bool onlyActivePlayers = false,
+        SeasonRange? seasons = null,
         CancellationToken cancellationToken = default);
     
     public Task<List<PlayerCareerPitchingDto>> GetHallOfFameCandidates(int seasonId,

--- a/SmbExplorerCompanion.Core/Interfaces/IPositionPlayerCareerRepository.cs
+++ b/SmbExplorerCompanion.Core/Interfaces/IPositionPlayerCareerRepository.cs
@@ -1,4 +1,5 @@
 ﻿using SmbExplorerCompanion.Core.Entities.Players;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 
 namespace SmbExplorerCompanion.Core.Interfaces;
 
@@ -13,6 +14,7 @@ public interface IPositionPlayerCareerRepository
         bool onlyHallOfFamers = false,
         int? primaryPositionId = null,
         bool onlyActivePlayers = false,
+        SeasonRange? seasons = null,
         CancellationToken cancellationToken = default);
     
     public Task<List<PlayerCareerBattingDto>> GetHallOfFameCandidates(int seasonId,

--- a/SmbExplorerCompanion.Core/Interfaces/ITeamRepository.cs
+++ b/SmbExplorerCompanion.Core/Interfaces/ITeamRepository.cs
@@ -1,11 +1,12 @@
 ﻿using SmbExplorerCompanion.Core.Entities.Teams;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 
 namespace SmbExplorerCompanion.Core.Interfaces;
 
 public interface ITeamRepository
 {
     public Task<IEnumerable<TeamDto>> GetSeasonTeams(int seasonId, CancellationToken cancellationToken);
-    public Task<IEnumerable<HistoricalTeamDto>> GetHistoricalTeams(int? seasonId, CancellationToken cancellationToken);
+    public Task<IEnumerable<HistoricalTeamDto>> GetHistoricalTeams(SeasonRange seasonRange, CancellationToken cancellationToken);
     public Task<TeamOverviewDto> GetTeamOverview(int teamId, CancellationToken cancellationToken);
     public Task<TeamSeasonDetailDto> GetTeamSeasonDetail(int teamSeasonId, CancellationToken cancellationToken);
 

--- a/SmbExplorerCompanion.Core/ValueObjects/Seasons/SeasonRange.cs
+++ b/SmbExplorerCompanion.Core/ValueObjects/Seasons/SeasonRange.cs
@@ -4,8 +4,8 @@ public record struct SeasonRange
 {
     public SeasonRange(int startSeasonId, int endSeasonId)
     {
-        if (startSeasonId >= endSeasonId)
-            throw new InvalidOperationException("Start cannot be equal or greater than End");
+        if (startSeasonId > endSeasonId)
+            throw new InvalidOperationException("Start cannot be greater than End");
         
         StartSeasonId = startSeasonId;
         EndSeasonId = endSeasonId;

--- a/SmbExplorerCompanion.Database/Services/Players/PitcherCareerRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/Players/PitcherCareerRepository.cs
@@ -163,6 +163,7 @@ public class PitcherCareerRepository : IPitcherCareerRepository
 
             pitchingDto.PlayerName = $"{player.FirstName} {player.LastName}";
             pitchingDto.IsPitcher = player.PitcherRoleId != null;
+            pitchingDto.PitcherRoleId = player.PitcherRoleId;
             pitchingDto.BatHandednessId = player.BatHandednessId;
             pitchingDto.ThrowHandednessId = player.ThrowHandednessId;
             pitchingDto.PrimaryPositionId = player.PrimaryPositionId;

--- a/SmbExplorerCompanion.Database/Services/Players/PitcherCareerRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/Players/PitcherCareerRepository.cs
@@ -69,27 +69,105 @@ public class PitcherCareerRepository : IPitcherCareerRepository
             .OrderByDescending(x => x.Id)
             .FirstAsync(cancellationToken);
 
-        var queryable = GetCareerPitchingIQueryable()
-            .Where(x => x.FranchiseId == franchiseId)
-            .Where(x => x.PitcherRole != null)
-            .Where(x => playerId == null || x.Id == playerId)
-            .Where(x => !onlyHallOfFamers || x.IsHallOfFamer)
-            .Where(x => !onlyActivePlayers || x.PlayerSeasons
-                .OrderByDescending(y => y.Id)
-                .First().SeasonId == mostRecentSeason.Id)
+        var playerPitchingDtos = await _dbContext.PlayerSeasons
+            .Include(x => x.Player)
+            .Include(x => x.PitchingStats)
+            .Where(x => x.Player.FranchiseId == franchiseId)
+            .Where(x => x.Player.PitcherRoleId != null)
+            .Where(x => playerId == null || x.PlayerId == playerId)
+            .Where(x => !onlyHallOfFamers || x.Player.IsHallOfFamer)
+            .Where(x => !onlyActivePlayers || x.SeasonId == mostRecentSeason.Id)
             .Where(x => seasons == null || (
-                x.PlayerSeasons.All(y => y.SeasonId >= seasons.Value.StartSeasonId && 
-                                         y.SeasonId <= seasons.Value.EndSeasonId)))
-            .Where(x => pitcherRoleId == null || x.PitcherRoleId == pitcherRoleId);
-
-        var playerPitchingDtos = await GetCareerPitchingDtos(queryable)
+                    x.SeasonId >= seasons.Value.StartSeasonId &&
+                    x.SeasonId <= seasons.Value.EndSeasonId
+                )
+            )
+            .Where(x => pitcherRoleId == null || x.Player.PitcherRoleId == pitcherRoleId)
+            .GroupBy(x => x.PlayerId)
+            .Select(x => new PlayerCareerPitchingDto
+            {
+                PlayerId = x.Key,
+                StartSeasonNumber = x.Min(y => y.Season.Number),
+                EndSeasonNumber = x.Max(y => y.Season.Number),
+                Age = x.Max(y => y.Age),
+                NumSeasons = x.Count(),
+                Wins = x.Sum(y => y.PitchingStats.Sum(z => z.Wins)),
+                Losses = x.Sum(y => y.PitchingStats.Sum(z => z.Losses)),
+                GamesStarted = x.Sum(y => y.PitchingStats.Sum(z => z.GamesStarted)),
+                Saves = x.Sum(y => y.PitchingStats.Sum(z => z.Saves)),
+                InningsPitched = x.Sum(y => y.PitchingStats.Sum(z => z.InningsPitched ?? 0)),
+                Strikeouts = x.Sum(y => y.PitchingStats.Sum(z => z.Strikeouts)),
+                CompleteGames = x.Sum(y => y.PitchingStats.Sum(z => z.CompleteGames)),
+                Shutouts = x.Sum(y => y.PitchingStats.Sum(z => z.Shutouts)),
+                Walks = x.Sum(y => y.PitchingStats.Sum(z => z.Walks)),
+                Hits = x.Sum(y => y.PitchingStats.Sum(z => z.Hits)),
+                HomeRuns = x.Sum(y => y.PitchingStats.Sum(z => z.HomeRuns)),
+                EarnedRuns = x.Sum(y => y.PitchingStats.Sum(z => z.EarnedRuns)),
+                TotalPitches = x.Sum(y => y.PitchingStats.Sum(z => z.TotalPitches)),
+                HitByPitch = x.Sum(y => y.PitchingStats.Sum(z => z.HitByPitch)),
+                WeightedOpsPlusOrEraMinus = x
+                    .SelectMany(y => y.PitchingStats)
+                    .Sum(y => (((y.EraMinus ?? 0) + (y.FipMinus ?? 0)) / 2 - 95) * (y.InningsPitched ?? 0) * PitchingScalingFactor),
+                EraMinus =
+                    x
+                        .SelectMany(y => y.PitchingStats)
+                        .Sum(y => (y.InningsPitched ?? 0)) > 0
+                        ? (x
+                               .SelectMany(y => y.PitchingStats)
+                               .Sum(y => (y.EraMinus ?? 0) * (y.InningsPitched ?? 0))
+                           /
+                           x
+                               .SelectMany(y => y.PitchingStats)
+                               .Sum(y => (y.InningsPitched ?? 0)))
+                        : 0,
+                FipMinus =
+                    x
+                        .SelectMany(y => y.PitchingStats)
+                        .Sum(y => (y.InningsPitched ?? 0)) > 0
+                        ? x
+                              .SelectMany(y => y.PitchingStats)
+                              .Sum(y => (y.FipMinus ?? 0) * (y.InningsPitched ?? 0))
+                          /
+                          x
+                              .SelectMany(y => y.PitchingStats)
+                              .Sum(y => (y.InningsPitched ?? 0))
+                        : 0,
+                AwardIds = x
+                    .SelectMany(y => y.Awards)
+                    .Where(y => !y.OmitFromGroupings)
+                    .Select(y => y.Id)
+                    .ToList(),
+                NumChampionships = x.Count(y => y.ChampionshipWinner != null),
+                TotalSalary = x
+                    .Sum(y => y.PlayerTeamHistory
+                        .Single(z => z.Order == 1).SeasonTeamHistoryId == null
+                        ? 0
+                        : y.Salary),
+            })
             .OrderBy(orderBy)
             .Skip(((pageNumber ?? 1) - 1) * limitValue)
             .Take(limitValue)
             .ToListAsync(cancellationToken: cancellationToken);
 
+        var playerIds = playerPitchingDtos
+            .Select(x => x.PlayerId)
+            .Distinct()
+            .ToList();
+        var players = await _dbContext.Players
+            .Where(x => playerIds.Contains(x.Id))
+            .ToListAsync(cancellationToken: cancellationToken);
+
         foreach (var pitchingDto in playerPitchingDtos)
         {
+            var player = players.Single(x => x.Id == pitchingDto.PlayerId);
+
+            pitchingDto.PlayerName = $"{player.FirstName} {player.LastName}";
+            pitchingDto.IsPitcher = player.PitcherRoleId != null;
+            pitchingDto.BatHandednessId = player.BatHandednessId;
+            pitchingDto.ThrowHandednessId = player.ThrowHandednessId;
+            pitchingDto.PrimaryPositionId = player.PrimaryPositionId;
+            pitchingDto.ChemistryId = player.ChemistryId;
+            pitchingDto.IsHallOfFamer = player.IsHallOfFamer;
             pitchingDto.IsRetired = pitchingDto.EndSeasonNumber < mostRecentSeason.Number;
             {
                 pitchingDto.RetiredCurrentAge = pitchingDto.Age + (mostRecentSeason.Number - pitchingDto.EndSeasonNumber);
@@ -191,7 +269,7 @@ public class PitcherCareerRepository : IPitcherCareerRepository
             if (pitchingDto.NumChampionships > 0)
                 foreach (var _ in Enumerable.Range(1, pitchingDto.NumChampionships))
                 {
-                    pitchingDto.AwardIds.Add((int)VirtualAward.Champion);
+                    pitchingDto.AwardIds.Add((int) VirtualAward.Champion);
                 }
         }
 

--- a/SmbExplorerCompanion.Database/Services/Players/PitcherSeasonRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/Players/PitcherSeasonRepository.cs
@@ -162,7 +162,8 @@ public class PitcherSeasonRepository : IPitcherSeasonRepository
                 StrikeoutsPerNine = x.StrikeoutsPerNine ?? 0,
                 StrikeoutToWalkRatio = x.StrikeoutsPerWalk ?? 0,
                 TraitIds = x.PlayerSeason.Traits.Select(y => y.Id).ToList(),
-                PitchTypeIds = x.PlayerSeason.PitchTypes.Select(y => y.Id).ToList()
+                PitchTypeIds = x.PlayerSeason.PitchTypes.Select(y => y.Id).ToList(),
+                PrimaryPositionId = x.PlayerSeason.Player.PrimaryPositionId
             })
             .OrderBy(orderBy)
             .Skip(((pageNumber ?? 1) - 1) * limitValue)

--- a/SmbExplorerCompanion.Database/Services/Players/PositionPlayerCareerRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/Players/PositionPlayerCareerRepository.cs
@@ -140,16 +140,21 @@ public class PositionPlayerCareerRepository : IPositionPlayerCareerRepository
             .Take(limitValue)
             .ToListAsync(cancellationToken: cancellationToken);
 
+        var playerIds = playerBattingDtos
+            .Select(x => x.PlayerId)
+            .Distinct()
+            .ToList();
+        var players = await _dbContext.Players
+            .Where(x => playerIds.Contains(x.Id))
+            .ToListAsync(cancellationToken: cancellationToken);
+
         // Calculate the rate stats that we omitted above
         foreach (var battingDto in playerBattingDtos)
         {
-            var player = await _dbContext.Players
-                .Where(x => x.Id == battingDto.PlayerId)
-                .SingleAsync(cancellationToken: cancellationToken);
-            
-            battingDto.PlayerId = player.Id;
+            var player = players.Single(x => x.Id == battingDto.PlayerId);
+
             battingDto.PlayerName = $"{player.FirstName} {player.LastName}";
-            battingDto.IsPitcher = player.PitcherRole != null;
+            battingDto.IsPitcher = player.PitcherRoleId != null;
             battingDto.BatHandednessId = player.BatHandednessId;
             battingDto.ThrowHandednessId = player.ThrowHandednessId;
             battingDto.PrimaryPositionId = player.PrimaryPositionId;

--- a/SmbExplorerCompanion.Database/Services/TeamRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/TeamRepository.cs
@@ -49,105 +49,69 @@ public class TeamRepository : ITeamRepository
         return teams;
     }
 
-    public async Task<IEnumerable<HistoricalTeamDto>> GetHistoricalTeams(int? seasonId,
+    public async Task<IEnumerable<HistoricalTeamDto>> GetHistoricalTeams(SeasonRange seasonRange,
         CancellationToken cancellationToken)
     {
         var franchiseId = _applicationContext.SelectedFranchiseId!.Value;
-        var teamsQueryable = _dbContext.Teams
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.Division)
+        var teamsQueryable = _dbContext.SeasonTeamHistory
+            .Include(x => x.Team)
+            .Include(x => x.Division)
             .ThenInclude(x => x.Conference)
-            .Where(x => x.FranchiseId == franchiseId);
+            .Where(x => x.Team.FranchiseId == franchiseId);
 
         var maxPlayoffSeries = await _dbContext.GetMaxPlayoffSeriesAsync(franchiseId, cancellationToken);
 
+        var isMultipleSeasons = seasonRange.StartSeasonId != seasonRange.EndSeasonId;
         int? previousSeasonId = null;
-        if (seasonId is not null)
+        if (!isMultipleSeasons)
         {
-            var seasons = await _dbContext.Seasons
+            var previousSeason = await _dbContext.Seasons
                 .Where(x => x.FranchiseId == franchiseId)
-                .ToListAsync(cancellationToken: cancellationToken);
-
-            if (seasons.All(x => x.Id != seasonId))
-                throw new Exception($"Season ID {seasonId} is not valid for franchise ID {franchiseId}");
-
-            var previousSeason = seasons
                 .OrderByDescending(x => x.Number)
-                .FirstOrDefault(x => x.Number < seasonId);
+                .FirstOrDefaultAsync(x => x.Number < seasonRange.StartSeasonId, cancellationToken);
 
             previousSeasonId = previousSeason?.Id;
         }
-
+        
         var teams = await teamsQueryable
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.TeamNameHistory)
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.PlayerTeamHistory)
+            .Include(x => x.TeamNameHistory)
+            .Include(x => x.PlayerTeamHistory)
             .ThenInclude(x => x.PlayerSeason)
             .ThenInclude(x => x.BattingStats)
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.PlayerTeamHistory)
-            .ThenInclude(x => x.PlayerSeason)
-            .ThenInclude(x => x.Player)
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.PlayerTeamHistory)
+            .Include(x => x.PlayerTeamHistory)
             .ThenInclude(x => x.PlayerSeason)
             .ThenInclude(x => x.PitchingStats)
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.HomePlayoffSchedule)
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.AwayPlayoffSchedule)
-            .Include(x => x.SeasonTeamHistory)
-            .ThenInclude(x => x.ChampionshipWinner)
+            .Include(x => x.HomePlayoffSchedule)
+            .Include(x => x.AwayPlayoffSchedule)
+            .Include(x => x.ChampionshipWinner)
+            .GroupBy(x => x.TeamId)
             .Select(x => new
             {
-                x.Id,
-                SeasonTeamId = seasonId == null
+                TeamId = x.Key,
+                SeasonTeamId = isMultipleSeasons
                     ? (int?) null
-                    : x.SeasonTeamHistory
-                        .First(y => y.SeasonId == seasonId).Id,
-                CurrentTeamName = x.SeasonTeamHistory
+                    : x.First().Id,
+                CurrentTeamName = x
                     .OrderByDescending(y => y.SeasonId)
                     .First().TeamNameHistory.Name,
-                NumGames = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Sum(y => y.Wins + y.Losses + (y.PlayoffWins ?? 0) + (y.PlayoffLosses ?? 0)),
-                NumRegularSeasonWins = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Sum(y => y.Wins),
-                WinDiffFromPrevSeason = seasonId != null && previousSeasonId != null
-                    ? (x.SeasonTeamHistory
-                        .Where(y => y.SeasonId == seasonId)
-                        .Sum(y => y.Wins)) - (x.SeasonTeamHistory
+                NumGames = x.Sum(y => y.Wins + y.Losses + (y.PlayoffWins ?? 0) + (y.PlayoffLosses ?? 0)),
+                NumRegularSeasonWins = x.Sum(y => y.Wins),
+                WinDiffFromPrevSeason = previousSeasonId != null
+                    ? (x
+                        .Where(y => y.SeasonId == seasonRange.EndSeasonId)
+                        .Sum(y => y.Wins)) - (x
                         .Where(y => y.SeasonId == previousSeasonId)
                         .Sum(y => y.Wins))
                     : 0,
-                NumRegularSeasonLosses = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Sum(y => y.Losses),
-                NumPlayoffWins = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Sum(y => y.PlayoffWins ?? 0),
-                NumPlayoffLosses = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Sum(y => y.PlayoffLosses ?? 0),
-                NumDivisionsWon = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Count(y => y.GamesBehind == 0),
-                NumChampionships = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Count(y => y.ChampionshipWinner != null),
-                NumPlayoffAppearances = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Count(y => y.HomePlayoffSchedule.Any() || y.AwayPlayoffSchedule.Any()),
-                NumRunsScored = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Sum(y => y.RunsScored + (y.PlayoffRunsScored ?? 0)),
-                NumRunsAllowed = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
-                    .Sum(y => y.RunsAllowed + (y.PlayoffRunsAllowed ?? 0)),
-                NumConferenceTitles = x.SeasonTeamHistory
-                    .Where(y => seasonId == null || y.SeasonId == seasonId)
+                NumRegularSeasonLosses = x.Sum(y => y.Losses),
+                NumPlayoffWins = x.Sum(y => y.PlayoffWins ?? 0),
+                NumPlayoffLosses = x.Sum(y => y.PlayoffLosses ?? 0),
+                NumDivisionsWon = x.Count(y => y.GamesBehind == 0),
+                NumChampionships = x.Count(y => y.ChampionshipWinner != null),
+                NumPlayoffAppearances = x.Count(y => y.HomePlayoffSchedule.Any() || y.AwayPlayoffSchedule.Any()),
+                NumRunsScored = x.Sum(y => y.RunsScored + (y.PlayoffRunsScored ?? 0)),
+                NumRunsAllowed = x.Sum(y => y.RunsAllowed + (y.PlayoffRunsAllowed ?? 0)),
+                NumConferenceTitles = x
                     .Select(seasonTeamHistory => seasonTeamHistory.HomePlayoffSchedule
                         .Where(y => y.SeriesNumber == maxPlayoffSeries)
                         .ToList())
@@ -169,12 +133,11 @@ public class TeamRepository : ITeamRepository
                 .Include(x => x.PlayerTeamHistory)
                 .ThenInclude(x => x.PlayerSeason)
                 .ThenInclude(x => x.PitchingStats)
-                .Where(x => x.TeamId == team.Id)
-                .Where(x => seasonId == null || x.SeasonId == seasonId)
+                .Where(x => x.TeamId == team.TeamId)
                 .SelectMany(y => y.PlayerTeamHistory)
                 .ToListAsync(cancellationToken: cancellationToken);
 
-            playerTeamHistories.Add(team.Id, playerTeamHistory);
+            playerTeamHistories.Add(team.TeamId, playerTeamHistory);
         }
 
         var historicalTeams = teams
@@ -182,7 +145,7 @@ public class TeamRepository : ITeamRepository
             {
                 var team = new HistoricalTeamDto
                 {
-                    TeamId = x.Id,
+                    TeamId = x.TeamId,
                     SeasonTeamId = x.SeasonTeamId,
                     CurrentTeamName = x.CurrentTeamName,
                     NumGames = x.NumGames,
@@ -199,7 +162,7 @@ public class TeamRepository : ITeamRepository
                     NumRunsAllowed = x.NumRunsAllowed,
                 };
 
-                var teamPlayers = playerTeamHistories[x.Id];
+                var teamPlayers = playerTeamHistories[x.TeamId];
 
                 team.NumPlayers = teamPlayers
                     .Select(y => y.PlayerSeason.PlayerId)
@@ -245,7 +208,7 @@ public class TeamRepository : ITeamRepository
 
         var currentSeason = await _dbContext.Seasons
             .Where(x => x.FranchiseId == franchiseId)
-            .Where(x => seasonId == null || x.Id == seasonId)
+            .Where(x => x.Id == seasonRange.EndSeasonId)
             .OrderByDescending(x => x.Number)
             .FirstAsync(cancellationToken: cancellationToken);
 

--- a/SmbExplorerCompanion.Database/Services/TeamRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/TeamRepository.cs
@@ -57,7 +57,8 @@ public class TeamRepository : ITeamRepository
             .Include(x => x.Team)
             .Include(x => x.Division)
             .ThenInclude(x => x.Conference)
-            .Where(x => x.Team.FranchiseId == franchiseId);
+            .Where(x => x.Team.FranchiseId == franchiseId)
+            .Where(x => x.SeasonId >= seasonRange.StartSeasonId && x.SeasonId <= seasonRange.EndSeasonId);
 
         var maxPlayoffSeries = await _dbContext.GetMaxPlayoffSeriesAsync(franchiseId, cancellationToken);
 
@@ -72,7 +73,7 @@ public class TeamRepository : ITeamRepository
 
             previousSeasonId = previousSeason?.Id;
         }
-        
+
         var teams = await teamsQueryable
             .Include(x => x.TeamNameHistory)
             .Include(x => x.PlayerTeamHistory)

--- a/SmbExplorerCompanion.Database/Services/TeamRepository.cs
+++ b/SmbExplorerCompanion.Database/Services/TeamRepository.cs
@@ -135,6 +135,7 @@ public class TeamRepository : ITeamRepository
                 .ThenInclude(x => x.PlayerSeason)
                 .ThenInclude(x => x.PitchingStats)
                 .Where(x => x.TeamId == team.TeamId)
+                .Where(x => x.SeasonId >= seasonRange.StartSeasonId && x.SeasonId <= seasonRange.EndSeasonId)
                 .SelectMany(y => y.PlayerTeamHistory)
                 .ToListAsync(cancellationToken: cancellationToken);
 

--- a/SmbExplorerCompanion.Database/SmbExplorerCompanionDbContext.cs
+++ b/SmbExplorerCompanion.Database/SmbExplorerCompanionDbContext.cs
@@ -1139,6 +1139,7 @@ public class SmbExplorerCompanionDbContext : DbContext
         if (dbContext.Database.GetPendingMigrations().Any()) dbContext.Database.Migrate();
     }
 
+    // TODO: This should be changed, as the playoff length may change throughout the years
     public async Task<int?> GetMaxPlayoffSeriesAsync(int franchiseId, CancellationToken cancellationToken = default)
     {
         var playoffSchedulesQueryable = TeamPlayoffSchedules

--- a/SmbExplorerCompanion.WPF/Models/Teams/TeamOverview.cs
+++ b/SmbExplorerCompanion.WPF/Models/Teams/TeamOverview.cs
@@ -27,6 +27,7 @@ public static class TeamOverviewExtensions
     {
         return new TeamOverview
         {
+            CurrentTeamName = x.CurrentTeamName,
             NumSeasons = x.NumSeasons,
             NumWins = x.NumWins,
             NumLosses = x.NumLosses,

--- a/SmbExplorerCompanion.WPF/Services/MappingService/PlayerCareerMappings.cs
+++ b/SmbExplorerCompanion.WPF/Services/MappingService/PlayerCareerMappings.cs
@@ -176,6 +176,31 @@ public partial class MappingService
             .Select(async y => await FromCore(y))
             .Select(y => y.Result)
             .ToObservableCollection();
+        
+        var awards = x.AwardIds
+            .Select(async y => await _lookupSearchService.GetPlayerAwardById(y))
+            .Select(y => y.Result)
+            .ToList();
+        
+        var playerSeasonBatting = x.PlayerSeasonBatting
+            .Select(async y => await FromCore(y))
+            .Select(y => y.Result)
+            .ToObservableCollection();
+        
+        var playerSeasonPitching = x.PlayerSeasonPitching
+            .Select(async y => await FromCore(y))
+            .Select(y => y.Result)
+            .ToObservableCollection();
+        
+        var playerPlayoffBatting = x.PlayerPlayoffBatting
+            .Select(async y => await FromCore(y))
+            .Select(y => y.Result)
+            .ToObservableCollection();
+        
+        var playerPlayoffPitching = x.PlayerPlayoffPitching
+            .Select(async y => await FromCore(y))
+            .Select(y => y.Result)
+            .ToObservableCollection();
 
         var overview = new PlayerOverview
         {
@@ -199,28 +224,13 @@ public partial class MappingService
             NumChampionships = x.NumChampionships,
             CurrentTeamId = x.CurrentTeamId,
             CurrentTeam = x.CurrentTeam,
-            Awards = x.AwardIds
-                .Select(async y => await _lookupSearchService.GetPlayerAwardById(y))
-                .Select(y => y.Result)
-                .ToList(),
+            Awards = awards,
             CareerBatting = careerBatting,
             CareerPitching = careerPitching,
-            PlayerSeasonBatting = x.PlayerSeasonBatting
-                .Select(async y => await FromCore(y))
-                .Select(y => y.Result)
-                .ToObservableCollection(),
-            PlayerSeasonPitching = x.PlayerSeasonPitching
-                .Select(async y => await FromCore(y))
-                .Select(y => y.Result)
-                .ToObservableCollection(),
-            PlayerPlayoffBatting = x.PlayerPlayoffBatting
-                .Select(async y => await FromCore(y))
-                .Select(y => y.Result)
-                .ToObservableCollection(),
-            PlayerPlayoffPitching = x.PlayerPlayoffPitching
-                .Select(async y => await FromCore(y))
-                .Select(y => y.Result)
-                .ToObservableCollection(),
+            PlayerSeasonBatting = playerSeasonBatting,
+            PlayerSeasonPitching = playerSeasonPitching,
+            PlayerPlayoffBatting = playerPlayoffBatting,
+            PlayerPlayoffPitching = playerPlayoffPitching,
             GameStats = gameStats,
             DisplayPrimaryPosition = PlayerDetailBaseExtensions.GetDisplayPrimaryPosition(position.Name, pitcherRole?.Name)
         };

--- a/SmbExplorerCompanion.WPF/Services/MappingService/PlayerSeasonMappings.cs
+++ b/SmbExplorerCompanion.WPF/Services/MappingService/PlayerSeasonMappings.cs
@@ -77,6 +77,17 @@ public partial class MappingService
             ? await _lookupSearchService.GetPitcherRoleById(pitcherRoleId.Value)
             : null;
 
+        var pitchTypes = x.PitchTypeIds
+            .Select(async y => await _lookupSearchService.GetPitchTypeById(y))
+            .Select(y => y.Result)
+            .OrderBy(y => y.Name)
+            .Select(y => y.Name);
+        
+        var awards = x.AwardIds
+            .Select(async y => await _lookupSearchService.GetPlayerAwardById(y))
+            .Select(y => y.Result)
+            .ToObservableCollection();
+
         return new PlayerSeasonPitching
         {
             PlayerId = x.PlayerId,
@@ -117,16 +128,8 @@ public partial class MappingService
             HomeRunsPerNine = x.HomeRunsPerNine,
             StrikeoutsPerNine = x.StrikeoutsPerNine,
             StrikeoutToWalkRatio = x.StrikeoutToWalkRatio,
-            PitchTypes = x.PitchTypeIds
-                .Select(async y => await _lookupSearchService.GetPitchTypeById(y))
-                .Select(y => y.Result)
-                .OrderBy(y => y.Name)
-                .Select(y => y.Name)
-                .Aggregate((current, next) => $"{current}, {next}"),
-            Awards = x.AwardIds
-                .Select(async y => await _lookupSearchService.GetPlayerAwardById(y))
-                .Select(y => y.Result)
-                .ToObservableCollection(),
+            PitchTypes = string.Join(", ", pitchTypes),
+            Awards = awards,
             DisplayPrimaryPosition = PlayerDetailBaseExtensions.GetDisplayPrimaryPosition(position?.Name ?? string.Empty, pitcherRole?.Name)
         };
     }

--- a/SmbExplorerCompanion.WPF/ViewModels/HistoricalTeamsViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/HistoricalTeamsViewModel.cs
@@ -83,6 +83,9 @@ public class HistoricalTeamsViewModel : ViewModelBase
 
     private async Task GetHistoricalTeams()
     {
+        if (StartSeason is not null && EndSeason is not null && StartSeason.Id > EndSeason.Id)
+            return;
+        
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
         HistoricalTeams.Clear();
 

--- a/SmbExplorerCompanion.WPF/ViewModels/HistoricalTeamsViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/HistoricalTeamsViewModel.cs
@@ -64,7 +64,7 @@ public class HistoricalTeamsViewModel : ViewModelBase
 
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
         var historicalTeams =
-            await _mediator.Send(new GetHistoricalTeamsRequest(SelectedSeason!.Id == default ? null : SelectedSeason!.Id));
+            await _mediator.Send(new GetHistoricalTeamsRequest());
 
         HistoricalTeams.AddRange(historicalTeams
             .Select(x => x.FromCore())

--- a/SmbExplorerCompanion.WPF/ViewModels/TopBattingCareersViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopBattingCareersViewModel.cs
@@ -146,7 +146,7 @@ public partial class TopBattingCareersViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void ClearSeasonRange()
+    private void ClearSeasons()
     {
         StartSeason = null;
         EndSeason = null;
@@ -195,7 +195,7 @@ public partial class TopBattingCareersViewModel : ViewModelBase
     public ObservableCollection<Season> SelectableEndSeasons
     {
         get => _selectableEndSeasons;
-        set => SetField(ref _selectableEndSeasons, value);
+        private set => SetField(ref _selectableEndSeasons, value);
     }
 
     public Season? StartSeason

--- a/SmbExplorerCompanion.WPF/ViewModels/TopBattingCareersViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopBattingCareersViewModel.cs
@@ -8,10 +8,13 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using MediatR;
 using SmbExplorerCompanion.Core.Commands.Queries.Players;
+using SmbExplorerCompanion.Core.Commands.Queries.Seasons;
 using SmbExplorerCompanion.Core.Entities.Players;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 using SmbExplorerCompanion.WPF.Extensions;
 using SmbExplorerCompanion.WPF.Models.Lookups;
 using SmbExplorerCompanion.WPF.Models.Players;
+using SmbExplorerCompanion.WPF.Models.Seasons;
 using SmbExplorerCompanion.WPF.Services;
 
 namespace SmbExplorerCompanion.WPF.ViewModels;
@@ -25,8 +28,12 @@ public partial class TopBattingCareersViewModel : ViewModelBase
     private PlayerBattingCareer? _selectedPlayer;
     private Position? _selectedPosition;
     private readonly MappingService _mappingService;
+    private Season? _startSeason;
+    private ObservableCollection<Season> _selectableEndSeasons;
+    private Season? _endSeason;
 
-    public TopBattingCareersViewModel(INavigationService navigationService,
+    public TopBattingCareersViewModel(
+        INavigationService navigationService,
         IMediator mediator,
         MappingService mappingService,
         LookupCache lookupCache)
@@ -46,8 +53,11 @@ public partial class TopBattingCareersViewModel : ViewModelBase
         };
         Positions.Add(allPosition);
         Positions.AddRange(positions.Where(x => x.IsPrimaryPosition));
-
         SelectedPosition = allPosition;
+        
+        var seasons = _mediator.Send(new GetSeasonsRequest()).Result;
+        Seasons.AddRange(seasons.Select(s => s.FromCore()));
+
         GetTopBattingCareers().Wait();
     }
 
@@ -97,6 +107,8 @@ public partial class TopBattingCareersViewModel : ViewModelBase
                     NavigateToPlayerOverview(SelectedPlayer);
                 break;
             }
+            case nameof(StartSeason):
+            case nameof(EndSeason):
             case nameof(SelectedPosition):
             case nameof(OnlyHallOfFamers):
             {
@@ -133,6 +145,13 @@ public partial class TopBattingCareersViewModel : ViewModelBase
         PageNumber--;
     }
 
+    [RelayCommand]
+    private void ClearSeasonRange()
+    {
+        StartSeason = null;
+        EndSeason = null;
+    }
+
     private void NavigateToPlayerOverview(PlayerBase player)
     {
         var parameters = new Tuple<string, object>[]
@@ -145,12 +164,19 @@ public partial class TopBattingCareersViewModel : ViewModelBase
     public async Task GetTopBattingCareers()
     {
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
+        SeasonRange? seasonRange = (StartSeason, EndSeason) switch
+        {
+            (not null, not null) => new SeasonRange(StartSeason.Id, EndSeason.Id),
+            _ => null
+        };
+
         var topPlayers = await _mediator.Send(new GetTopBattingCareersRequest(
             pageNumber: PageNumber,
             limit: ResultsPerPage,
             orderBy: SortColumn,
             onlyHallOfFamers: OnlyHallOfFamers,
-            primaryPositionId: SelectedPosition?.Id == 0 ? null : SelectedPosition?.Id
+            primaryPositionId: SelectedPosition?.Id == 0 ? null : SelectedPosition?.Id,
+            seasonRange: seasonRange
         ));
 
         TopBattingCareers.Clear();
@@ -162,6 +188,40 @@ public partial class TopBattingCareersViewModel : ViewModelBase
         IncrementPageCommand.NotifyCanExecuteChanged();
         DecrementPageCommand.NotifyCanExecuteChanged();
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = null);
+    }
+
+    public ObservableCollection<Season> Seasons { get; } = new();
+
+    public ObservableCollection<Season> SelectableEndSeasons
+    {
+        get => _selectableEndSeasons;
+        set => SetField(ref _selectableEndSeasons, value);
+    }
+
+    public Season? StartSeason
+    {
+        get => _startSeason;
+        set
+        {
+            SetField(ref _startSeason, value);
+            
+            if (value is not null)
+            {
+                var endSeasons = Seasons.Where(x => x.Id >= value.Id).ToList();
+                SelectableEndSeasons = new ObservableCollection<Season>(endSeasons);
+                EndSeason = endSeasons.LastOrDefault();
+            }
+            else
+            {
+                EndSeason = null;
+            }
+        }
+    }
+
+    public Season? EndSeason
+    {
+        get => _endSeason;
+        set => SetField(ref _endSeason, value);
     }
 
     protected override void Dispose(bool disposing)

--- a/SmbExplorerCompanion.WPF/ViewModels/TopBattingCareersViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopBattingCareersViewModel.cs
@@ -163,6 +163,9 @@ public partial class TopBattingCareersViewModel : ViewModelBase
 
     public async Task GetTopBattingCareers()
     {
+        if (StartSeason is not null && EndSeason is not null && StartSeason.Id > EndSeason.Id)
+            return;
+
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
         SeasonRange? seasonRange = (StartSeason, EndSeason) switch
         {

--- a/SmbExplorerCompanion.WPF/ViewModels/TopBattingSeasonsViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopBattingSeasonsViewModel.cs
@@ -236,6 +236,9 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
 
     public async Task GetTopBattingSeason()
     {
+        if (StartSeason is not null && EndSeason is not null && StartSeason.Id > EndSeason.Id)
+            return;
+
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
         var seasonRange = (StartSeason, EndSeason) switch
         {

--- a/SmbExplorerCompanion.WPF/ViewModels/TopBattingSeasonsViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopBattingSeasonsViewModel.cs
@@ -26,10 +26,12 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
     private bool _isPlayoffs;
     private int _pageNumber = 1;
     private PlayerSeasonBase? _selectedPlayer;
-    private Season? _selectedSeason;
+    private Season? _startSeason;
     private bool _onlyRookies;
     private Position? _selectedPosition;
     private readonly MappingService _mappingService;
+    private Season? _endSeason;
+    private ObservableCollection<Season> _selectableEndSeasons;
 
     public TopBattingSeasonsViewModel(IMediator mediator,
         INavigationService navigationService,
@@ -43,16 +45,10 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
 
         var seasons = _mediator.Send(new GetSeasonsRequest()).Result;
         Seasons.AddRange(seasons.Select(s => s.FromCore()));
-        SelectedSeason = Seasons.OrderByDescending(x => x.Number).First();
+        StartSeason = Seasons.OrderByDescending(x => x.Number).First();
         MinSeasonId = Seasons.OrderBy(x => x.Number).First().Id;
 
-        Seasons.Add(new Season
-        {
-            Id = default
-        });
-
         var positions = lookupCache.GetPositions().Result;
-
         var allPosition = new Position
         {
             Id = 0,
@@ -85,9 +81,9 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
 
     private int MinSeasonId { get; }
 
-    public Season? SelectedSeason
+    public Season? StartSeason
     {
-        get => _selectedSeason;
+        get => _startSeason;
         set
         {
             if (value is not null && (value.Id == default || value.Id == MinSeasonId))
@@ -97,8 +93,41 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
                 ShortCircuitOnlyRookiesRefresh = false;
             }
 
-            SetField(ref _selectedSeason, value);
+            SetField(ref _startSeason, value);
+            OnPropertyChanged(nameof(CanSelectOnlyRookies));
+            
+            if (value is not null)
+            {
+                var endSeasons = Seasons.Where(x => x.Id >= value.Id).ToList();
+                SelectableEndSeasons = new ObservableCollection<Season>(endSeasons);
+                EndSeason = endSeasons.LastOrDefault();
+            }
+            else
+            {
+                EndSeason = null;
+            }
+        }
+    }
 
+    public ObservableCollection<Season> SelectableEndSeasons
+    {
+        get => _selectableEndSeasons;
+        private set => SetField(ref _selectableEndSeasons, value);
+    }
+
+    public Season? EndSeason
+    {
+        get => _endSeason;
+        set
+        {
+            if (value is not null && value.Id != StartSeason?.Id)
+            {
+                ShortCircuitOnlyRookiesRefresh = true;
+                OnlyRookies = false;
+                ShortCircuitOnlyRookiesRefresh = false;
+            }
+
+            SetField(ref _endSeason, value);
             OnPropertyChanged(nameof(CanSelectOnlyRookies));
         }
     }
@@ -138,9 +167,10 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
     {
         get
         {
-            if (SelectedSeason is null) return false;
-            if (SelectedSeason.Id == default) return false;
-            if (SelectedSeason.Id == MinSeasonId) return false;
+            if (StartSeason is null) return false;
+            if (StartSeason.Id == default) return false;
+            if (StartSeason.Id == MinSeasonId) return false;
+            if (StartSeason.Id != EndSeason?.Id) return false;
 
             return true;
         }
@@ -170,7 +200,8 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
         {
             case nameof(OnlyRookies):
             case nameof(IsPlayoffs):
-            case nameof(SelectedSeason):
+            case nameof(StartSeason):
+            case nameof(EndSeason):
             case nameof(SelectedPosition):
             {
                 ShortCircuitPageNumberRefresh = true;
@@ -198,8 +229,16 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
     public async Task GetTopBattingSeason()
     {
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
+        var seasonRange = (StartSeason, EndSeason) switch
+        {
+            (null, null) => new SeasonRange(MinSeasonId),
+            (not null, null) => new SeasonRange(StartSeason.Id),
+            (null, not null) => new SeasonRange(MinSeasonId, EndSeason.Id),
+            (not null, not null) => new SeasonRange(StartSeason.Id, EndSeason.Id),
+        };
+
         var topBatters = await _mediator.Send(new GetTopBattingSeasonRequest(
-            seasons: SelectedSeason!.Id == default ? null : new SeasonRange(SelectedSeason!.Id),
+            seasons: seasonRange,
             isPlayoffs: IsPlayoffs,
             pageNumber: PageNumber,
             orderBy: SortColumn,

--- a/SmbExplorerCompanion.WPF/ViewModels/TopBattingSeasonsViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopBattingSeasonsViewModel.cs
@@ -95,12 +95,13 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
 
             SetField(ref _startSeason, value);
             OnPropertyChanged(nameof(CanSelectOnlyRookies));
-            
+    
             if (value is not null)
             {
                 var endSeasons = Seasons.Where(x => x.Id >= value.Id).ToList();
                 SelectableEndSeasons = new ObservableCollection<Season>(endSeasons);
-                EndSeason = endSeasons.LastOrDefault();
+                if (EndSeason is null || EndSeason.Id < value.Id)
+                    EndSeason = endSeasons.LastOrDefault();
             }
             else
             {
@@ -113,6 +114,13 @@ public partial class TopBattingSeasonsViewModel : ViewModelBase
     {
         get => _selectableEndSeasons;
         private set => SetField(ref _selectableEndSeasons, value);
+    }
+
+    [RelayCommand]
+    private void ClearSeasons()
+    {
+        StartSeason = Seasons.OrderBy(x => x.Id).Last();
+        EndSeason = Seasons.OrderBy(x => x.Id).Last();
     }
 
     public Season? EndSeason

--- a/SmbExplorerCompanion.WPF/ViewModels/TopPitchingCareersViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopPitchingCareersViewModel.cs
@@ -197,6 +197,9 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
 
     public async Task GetTopPitchingCareers()
     {
+        if (StartSeason is not null && EndSeason is not null && StartSeason.Id > EndSeason.Id)
+            return;
+
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
         SeasonRange? seasonRange = (StartSeason, EndSeason) switch
         {

--- a/SmbExplorerCompanion.WPF/ViewModels/TopPitchingCareersViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopPitchingCareersViewModel.cs
@@ -42,8 +42,6 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
         _navigationService = navigationService;
         _mappingService = mappingService;
 
-        PropertyChanged += OnPropertyChanged;
-
         var pitcherRoles = lookupCache.GetPitcherRoles().Result;
         var allPitcherRole = new PitcherRole
         {
@@ -53,15 +51,16 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
         PitcherRoles.Add(allPitcherRole);
         PitcherRoles.AddRange(pitcherRoles);
         SelectedPitcherRole = allPitcherRole;
-        
+
         var seasons = _mediator.Send(new GetSeasonsRequest()).Result;
         Seasons.AddRange(seasons.Select(s => s.FromCore()));
 
         GetTopPitchingCareers().Wait();
+        PropertyChanged += OnPropertyChanged;
 
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = null);
     }
-    
+
     public ObservableCollection<Season> Seasons { get; } = new();
 
     public ObservableCollection<Season> SelectableEndSeasons
@@ -76,7 +75,7 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
         set
         {
             SetField(ref _startSeason, value);
-            
+
             if (value is not null)
             {
                 var endSeasons = Seasons.Where(x => x.Id >= value.Id).ToList();
@@ -108,7 +107,7 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
             DecrementPageCommand.NotifyCanExecuteChanged();
         }
     }
-    
+
     [RelayCommand]
     private void ClearSeasons()
     {

--- a/SmbExplorerCompanion.WPF/ViewModels/TopPitchingCareersViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopPitchingCareersViewModel.cs
@@ -8,10 +8,13 @@ using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using MediatR;
 using SmbExplorerCompanion.Core.Commands.Queries.Players;
+using SmbExplorerCompanion.Core.Commands.Queries.Seasons;
 using SmbExplorerCompanion.Core.Entities.Players;
+using SmbExplorerCompanion.Core.ValueObjects.Seasons;
 using SmbExplorerCompanion.WPF.Extensions;
 using SmbExplorerCompanion.WPF.Models.Lookups;
 using SmbExplorerCompanion.WPF.Models.Players;
+using SmbExplorerCompanion.WPF.Models.Seasons;
 using SmbExplorerCompanion.WPF.Services;
 
 namespace SmbExplorerCompanion.WPF.ViewModels;
@@ -25,6 +28,9 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
     private PlayerPitchingCareer? _selectedPlayer;
     private PitcherRole? _selectedPitcherRole;
     private readonly MappingService _mappingService;
+    private ObservableCollection<Season> _selectableEndSeasons;
+    private Season? _startSeason;
+    private Season? _endSeason;
 
     public TopPitchingCareersViewModel(IMediator mediator,
         INavigationService navigationService,
@@ -46,12 +52,48 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
         };
         PitcherRoles.Add(allPitcherRole);
         PitcherRoles.AddRange(pitcherRoles);
-
         SelectedPitcherRole = allPitcherRole;
+        
+        var seasons = _mediator.Send(new GetSeasonsRequest()).Result;
+        Seasons.AddRange(seasons.Select(s => s.FromCore()));
 
         GetTopPitchingCareers().Wait();
 
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = null);
+    }
+    
+    public ObservableCollection<Season> Seasons { get; } = new();
+
+    public ObservableCollection<Season> SelectableEndSeasons
+    {
+        get => _selectableEndSeasons;
+        private set => SetField(ref _selectableEndSeasons, value);
+    }
+
+    public Season? StartSeason
+    {
+        get => _startSeason;
+        set
+        {
+            SetField(ref _startSeason, value);
+            
+            if (value is not null)
+            {
+                var endSeasons = Seasons.Where(x => x.Id >= value.Id).ToList();
+                SelectableEndSeasons = new ObservableCollection<Season>(endSeasons);
+                EndSeason = endSeasons.LastOrDefault();
+            }
+            else
+            {
+                EndSeason = null;
+            }
+        }
+    }
+
+    public Season? EndSeason
+    {
+        get => _endSeason;
+        set => SetField(ref _endSeason, value);
     }
 
     public int PageNumber
@@ -65,6 +107,13 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
             IncrementPageCommand.NotifyCanExecuteChanged();
             DecrementPageCommand.NotifyCanExecuteChanged();
         }
+    }
+    
+    [RelayCommand]
+    private void ClearSeasons()
+    {
+        StartSeason = null;
+        EndSeason = null;
     }
 
     public bool OnlyHallOfFamers
@@ -100,6 +149,8 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
                     NavigateToPlayerOverview(SelectedPlayer);
                 break;
             }
+            case nameof(StartSeason):
+            case nameof(EndSeason):
             case nameof(SelectedPitcherRole):
             case nameof(OnlyHallOfFamers):
             {
@@ -148,12 +199,19 @@ public partial class TopPitchingCareersViewModel : ViewModelBase
     public async Task GetTopPitchingCareers()
     {
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
+        SeasonRange? seasonRange = (StartSeason, EndSeason) switch
+        {
+            (not null, not null) => new SeasonRange(StartSeason.Id, EndSeason.Id),
+            _ => null
+        };
+
         var topPitchers = await _mediator.Send(new GetTopPitchingCareersRequest(
             pageNumber: PageNumber,
             limit: ResultsPerPage,
             orderBy: SortColumn,
             onlyHallOfFamers: OnlyHallOfFamers,
-            pitcherRoleId: SelectedPitcherRole?.Id == 0 ? null : SelectedPitcherRole?.Id
+            pitcherRoleId: SelectedPitcherRole?.Id == 0 ? null : SelectedPitcherRole?.Id,
+            seasonRange: seasonRange
         ));
 
         TopPitchingCareers.Clear();

--- a/SmbExplorerCompanion.WPF/ViewModels/TopPitchingSeasonsViewModel.cs
+++ b/SmbExplorerCompanion.WPF/ViewModels/TopPitchingSeasonsViewModel.cs
@@ -236,6 +236,9 @@ public partial class TopPitchingSeasonsViewModel : ViewModelBase
 
     public async Task GetTopPitchingSeason()
     {
+        if (StartSeason is not null && EndSeason is not null && StartSeason.Id > EndSeason.Id)
+            return;
+
         Application.Current.Dispatcher.Invoke(() => Mouse.OverrideCursor = Cursors.Wait);
         var seasonRange = (StartSeason, EndSeason) switch
         {

--- a/SmbExplorerCompanion.WPF/Views/HistoricalTeamsView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/HistoricalTeamsView.xaml
@@ -18,9 +18,18 @@
                 DockPanel.Dock="Left"
                 Width="200"
                 Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
-                materialDesign:HintAssist.Hint="Season"
+                materialDesign:HintAssist.Hint="Start Season"
                 ItemsSource="{Binding Seasons}"
-                SelectedItem="{Binding SelectedSeason}"
+                SelectedItem="{Binding StartSeason}"
+                DisplayMemberPath="DisplaySeasonNumber" />
+
+            <ComboBox
+                DockPanel.Dock="Left"
+                Width="200"
+                Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
+                materialDesign:HintAssist.Hint="End Season"
+                ItemsSource="{Binding SelectableEndSeasons}"
+                SelectedItem="{Binding EndSeason}"
                 DisplayMemberPath="DisplaySeasonNumber" />
         </DockPanel>
 

--- a/SmbExplorerCompanion.WPF/Views/TopBattingCareersView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopBattingCareersView.xaml
@@ -52,6 +52,11 @@
                 ItemsSource="{Binding SelectableEndSeasons}"
                 SelectedItem="{Binding EndSeason}"
                 DisplayMemberPath="DisplaySeasonNumber" />
+
+            <Button
+                Command="{Binding ClearSeasonsCommand}"
+                Content="Clear Seasons" />
+
             <ComboBox
                 Margin="2"
                 Width="200"

--- a/SmbExplorerCompanion.WPF/Views/TopBattingCareersView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopBattingCareersView.xaml
@@ -36,6 +36,23 @@
                     IsChecked="{Binding OnlyHallOfFamers}" />
             </StackPanel>
             <ComboBox
+                DockPanel.Dock="Left"
+                Width="200"
+                Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
+                materialDesign:HintAssist.Hint="Start Season"
+                ItemsSource="{Binding Seasons}"
+                SelectedItem="{Binding StartSeason}"
+                DisplayMemberPath="DisplaySeasonNumber" />
+            
+            <ComboBox
+                DockPanel.Dock="Left"
+                Width="200"
+                Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
+                materialDesign:HintAssist.Hint="End Season"
+                ItemsSource="{Binding SelectableEndSeasons}"
+                SelectedItem="{Binding EndSeason}"
+                DisplayMemberPath="DisplaySeasonNumber" />
+            <ComboBox
                 Margin="2"
                 Width="200"
                 Style="{DynamicResource MaterialDesignFloatingHintComboBox}"

--- a/SmbExplorerCompanion.WPF/Views/TopBattingSeasonsView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopBattingSeasonsView.xaml
@@ -31,6 +31,10 @@
                 ItemsSource="{Binding SelectableEndSeasons}"
                 SelectedItem="{Binding EndSeason}"
                 DisplayMemberPath="DisplaySeasonNumber" />
+            
+            <Button
+                Command="{Binding ClearSeasonsCommand}"
+                Content="Clear Seasons" />
 
             <ComboBox
                 Margin="2"

--- a/SmbExplorerCompanion.WPF/Views/TopBattingSeasonsView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopBattingSeasonsView.xaml
@@ -18,11 +18,20 @@
                 DockPanel.Dock="Left"
                 Width="200"
                 Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
-                materialDesign:HintAssist.Hint="Season"
+                materialDesign:HintAssist.Hint="Start Season"
                 ItemsSource="{Binding Seasons}"
-                SelectedItem="{Binding SelectedSeason}"
+                SelectedItem="{Binding StartSeason}"
                 DisplayMemberPath="DisplaySeasonNumber" />
             
+            <ComboBox
+                DockPanel.Dock="Left"
+                Width="200"
+                Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
+                materialDesign:HintAssist.Hint="End Season"
+                ItemsSource="{Binding SelectableEndSeasons}"
+                SelectedItem="{Binding EndSeason}"
+                DisplayMemberPath="DisplaySeasonNumber" />
+
             <ComboBox
                 Margin="2"
                 Width="200"

--- a/SmbExplorerCompanion.WPF/Views/TopBattingSeasonsView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopBattingSeasonsView.xaml
@@ -22,7 +22,7 @@
                 ItemsSource="{Binding Seasons}"
                 SelectedItem="{Binding StartSeason}"
                 DisplayMemberPath="DisplaySeasonNumber" />
-            
+
             <ComboBox
                 DockPanel.Dock="Left"
                 Width="200"
@@ -31,7 +31,7 @@
                 ItemsSource="{Binding SelectableEndSeasons}"
                 SelectedItem="{Binding EndSeason}"
                 DisplayMemberPath="DisplaySeasonNumber" />
-            
+
             <Button
                 Command="{Binding ClearSeasonsCommand}"
                 Content="Clear Seasons" />
@@ -43,7 +43,7 @@
                 materialDesign:HintAssist.Hint="Position"
                 ItemsSource="{Binding Positions}"
                 DisplayMemberPath="Name"
-                SelectedItem="{Binding SelectedPosition}"/>
+                SelectedItem="{Binding SelectedPosition}" />
 
             <StackPanel
                 DockPanel.Dock="Right"

--- a/SmbExplorerCompanion.WPF/Views/TopPitchingCareersView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopPitchingCareersView.xaml
@@ -35,6 +35,29 @@
                 <CheckBox
                     IsChecked="{Binding OnlyHallOfFamers}" />
             </StackPanel>
+
+            <ComboBox
+                DockPanel.Dock="Left"
+                Width="200"
+                Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
+                materialDesign:HintAssist.Hint="Start Season"
+                ItemsSource="{Binding Seasons}"
+                SelectedItem="{Binding StartSeason}"
+                DisplayMemberPath="DisplaySeasonNumber" />
+
+            <ComboBox
+                DockPanel.Dock="Left"
+                Width="200"
+                Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
+                materialDesign:HintAssist.Hint="End Season"
+                ItemsSource="{Binding SelectableEndSeasons}"
+                SelectedItem="{Binding EndSeason}"
+                DisplayMemberPath="DisplaySeasonNumber" />
+
+            <Button
+                Command="{Binding ClearSeasonsCommand}"
+                Content="Clear Seasons" />
+
             <ComboBox
                 Margin="2"
                 Width="200"

--- a/SmbExplorerCompanion.WPF/Views/TopPitchingCareersView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopPitchingCareersView.xaml
@@ -103,7 +103,7 @@
                 <DataGridTextColumn
                     CanUserSort="False"
                     Header="Pitcher Role"
-                    Binding="{Binding PitcherRole}" />
+                    Binding="{Binding DisplayPrimaryPosition}" />
                 <DataGridTemplateColumn
                     CanUserSort="True"
                     Header="Career Earnings"

--- a/SmbExplorerCompanion.WPF/Views/TopPitchingSeasonsView.xaml
+++ b/SmbExplorerCompanion.WPF/Views/TopPitchingSeasonsView.xaml
@@ -18,10 +18,23 @@
                 DockPanel.Dock="Left"
                 Width="200"
                 Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
-                materialDesign:HintAssist.Hint="Season"
+                materialDesign:HintAssist.Hint="Start Season"
                 ItemsSource="{Binding Seasons}"
-                SelectedItem="{Binding SelectedSeason}"
+                SelectedItem="{Binding StartSeason}"
                 DisplayMemberPath="DisplaySeasonNumber" />
+
+            <ComboBox
+                DockPanel.Dock="Left"
+                Width="200"
+                Style="{DynamicResource MaterialDesignFloatingHintComboBox}"
+                materialDesign:HintAssist.Hint="End Season"
+                ItemsSource="{Binding SelectableEndSeasons}"
+                SelectedItem="{Binding EndSeason}"
+                DisplayMemberPath="DisplaySeasonNumber" />
+
+            <Button
+                Command="{Binding ClearSeasonsCommand}"
+                Content="Clear Seasons" />
 
             <ComboBox
                 Margin="2"


### PR DESCRIPTION
- Add season range (start, end season selection) grid filters for the following grids:
  - Seasons - position players and pitchers (displays individual seasons for the given season range)
  - Careers - position players and pitchers (aggregates data for the given season range)
  - Teams (aggregates the same as above)

Closes #136 